### PR TITLE
Change filesystem permission to host

### DIFF
--- a/rs.ruffle.Ruffle.yaml
+++ b/rs.ruffle.Ruffle.yaml
@@ -20,7 +20,7 @@ finish-args:
   # An opened movie may load neighboring files,
   # this makes sure we also have access to those files.
   # It is rw, because the file picker requires write access by default.
-  - --filesystem=home
+  - --filesystem=host
 
 add-extensions:
   org.freedesktop.Platform.openh264:


### PR DESCRIPTION
Until https://github.com/flathub/rs.ruffle.Ruffle/issues/38 is resolved upstream, this makes it possible to load files from external drives by default.

See <https://docs.flatpak.org/en/latest/flatpak-command-reference.html#:~:text=The%20entire%20host%20file%20system>.