### PR TITLE
Revert "Add OpenH264 as an extension"

### DIFF
--- a/rs.ruffle.Ruffle.yaml
+++ b/rs.ruffle.Ruffle.yaml
@@ -22,15 +22,6 @@ finish-args:
   # It is rw, because the file picker requires write access by default.
   - --filesystem=home
 
-add-extensions:
-  org.freedesktop.Platform.openh264:
-    version: 2.4.1
-    directory: lib/openh264
-    add-ld-path: extra
-
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/openh264
-
 modules:
   - name: ruffle
     buildsystem: simple


### PR DESCRIPTION
This reverts commit a5855af10f08cf0b1a45688a2c986e6bc4f7a6bc.

When OpenH264 fails to download as an extension, it prevents Ruffle from being installed at all.  Considering that OpenH264 is not an essential library and OpenH264 is blocked in some countries, this patch drops the hard dependency to the extension, instead relying on downloading the library at runtime.